### PR TITLE
feat: add docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:alpine AS backend
+
+COPY ./backend /backend
+COPY ./depends /depends
+
+WORKDIR /backend
+
+RUN go build \
+    -ldflags "-X github.com/cubefs/cubefs/proto.Version=$(git describe --abbrev=0 --tags 2>/dev/null) \
+    -X github.com/cubefs/cubefs/proto.CommitID=$(git rev-parse HEAD 2>/dev/null) \
+    -X github.com/cubefs/cubefs/proto.BranchName=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) \
+    -X 'github.com/cubefs/cubefs/proto.BuildTime=$(date +%Y-%m-%d\ %H:%M)'" \
+    -o /bin/cfs-gui \
+    *.go
+
+FROM node:14 AS frontend
+
+COPY ./frontend /frontend
+
+WORKDIR /frontend
+
+RUN npm install && npm run build
+
+FROM alpine:latest
+
+COPY --from=backend /bin/cfs-gui /app/cfs-gui
+COPY --from=frontend /frontend/dist /app/dist
+
+WORKDIR /app
+
+CMD ["/app/cfs-gui", "-c", "/app/config.yml"]


### PR DESCRIPTION
## Usage
Add `config.yml` to the host:
```bash
server:
  port: 6007  //服务监听端口
  mode: dev   //运行模式 test dev prod
  static_resource:
    enable: true  //是否开启静态资源
    relative_path: /portal  //静态资源前缀
    root_path: ./dist  //静态资源目录  默认在运行的目录下
prefix:
  api: /api/cubefs //后端接口前缀
mysql:
  host: xxxxxx   //mysql 读写域名
  port: xxxxxx   //mysql 读写域名的端口
  slaveHost: xxxxxx   //mysql 只读域名，没有的话可以填读写域名
  slavePort: xxxxxx   //mysql 只读域名的端口，没有的话可以填读写域名的端口
  user: xxxxxx   //mysql  用户名
  password: xxxxxx   //mysql  密码（此处不能是明文密码，需要先加密）
  database: xxxxxx   //mysql  数据库名
  maxIdleConn: 20
  MaxOpenConn: 300
```
Encrypt password:
```bash
$ docker run cubefs-dashboard:latest /app/cfs-gui -e 123456
shH2bjoxp8hWG3cisjKf6g==
```
Run docker:
```bash
$ docker run -d \
  --name=cubefs-dashboard \
  -p 6007:6007 \
  -v /path/to/config.yml:/app/config.yml \
  cubefs-dashboard:latest
```